### PR TITLE
Fix/jwt server component auth

### DIFF
--- a/app/admin/review/page.tsx
+++ b/app/admin/review/page.tsx
@@ -1,17 +1,48 @@
-import { getSessionUser } from '@/lib/auth'
-import { redirect } from 'next/navigation'
+'use client'
+
+import { getCurrentUser } from '@/lib/auth-client'
+import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import ReviewArticleList from '@/components/Admin/ReviewArticleList'
+import { useEffect, useState } from 'react'
 
-export const dynamic = 'force-dynamic' // 쿠키 사용으로 인해 동적 렌더링 필요
+export default function ReviewPage() {
+  const router = useRouter()
+  const [isChecking, setIsChecking] = useState(true)
+  const [isAuthorized, setIsAuthorized] = useState(false)
 
-export default async function ReviewPage() {
-  const user = await getSessionUser()
-  
-  if (!user || user.role !== 'admin') {
-    redirect('/')
+  useEffect(() => {
+    const checkAuth = async () => {
+      try {
+        const user = await getCurrentUser()
+        if (user && user.role === 'admin') {
+          setIsAuthorized(true)
+        } else {
+          router.push('/')
+        }
+      } catch (error) {
+        console.error('Auth check error:', error)
+        router.push('/')
+      } finally {
+        setIsChecking(false)
+      }
+    }
+
+    checkAuth()
+  }, [router])
+
+  if (isChecking) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <div className="text-text-primary">로딩 중...</div>
+      </div>
+    )
   }
-  
+
+  if (!isAuthorized) {
+    return null
+  }
+
   return (
     <div className="min-h-screen bg-background">
       <header className="bg-surface border-b border-border">

--- a/app/articles/new/page.tsx
+++ b/app/articles/new/page.tsx
@@ -1,17 +1,48 @@
+'use client'
+
 import AutoLinkEditor from '@/components/Editor/AutoLinkEditor'
-import { getSessionUser } from '@/lib/auth'
+import { getCurrentUser } from '@/lib/auth-client'
 import Link from 'next/link'
-import { redirect } from 'next/navigation'
+import { useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
 
-export const dynamic = 'force-dynamic'
+export default function NewArticlePage() {
+  const router = useRouter()
+  const [isChecking, setIsChecking] = useState(true)
+  const [isAuthorized, setIsAuthorized] = useState(false)
 
-export default async function NewArticlePage() {
-  const user = await getSessionUser()
-  
-  if (!user) {
-    redirect('/auth/login?redirect=/articles/new')
+  useEffect(() => {
+    const checkAuth = async () => {
+      try {
+        const user = await getCurrentUser()
+        if (user) {
+          setIsAuthorized(true)
+        } else {
+          router.push('/auth/login?redirect=/articles/new')
+        }
+      } catch (error) {
+        console.error('Auth check error:', error)
+        router.push('/auth/login?redirect=/articles/new')
+      } finally {
+        setIsChecking(false)
+      }
+    }
+
+    checkAuth()
+  }, [router])
+
+  if (isChecking) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <div className="text-text-primary">로딩 중...</div>
+      </div>
+    )
   }
-  
+
+  if (!isAuthorized) {
+    return null
+  }
+
   return (
     <div className="min-h-screen bg-background">
       <header className="bg-surface border-b border-border">

--- a/docs/SUPABASE_LOCAL_CONNECTION_FIX.md
+++ b/docs/SUPABASE_LOCAL_CONNECTION_FIX.md
@@ -1,0 +1,104 @@
+# 로컬 Supabase 연결 문제 해결
+
+## 🔴 현재 오류
+
+```
+Can't reach database server at `aws-1-ap-northeast-2.pooler.supabase.com:5432`
+```
+
+## 🔍 가능한 원인
+
+1. **Session Pooler가 로컬 네트워크에서 차단됨**
+   - Session Pooler는 클라우드 환경(Vercel)에 최적화되어 있음
+   - 로컬 개발 환경에서는 Direct Connection이 더 안정적일 수 있음
+
+2. **Supabase 프로젝트 일시 중지**
+   - 무료 플랜의 경우 7일간 비활성화 시 자동 일시 중지
+   - Dashboard에서 "Active"로 보여도 실제로는 연결 불가능할 수 있음
+
+3. **비밀번호 URL 인코딩 문제**
+   - 특수문자(`!`, `@`, `#` 등)가 URL 인코딩되지 않음
+   - `!` → `%21`로 변환 필요
+
+## 🛠️ 해결 방법
+
+### 방법 1: Direct Connection으로 변경 ⭐ (권장)
+
+로컬 개발 환경에서는 Direct Connection을 사용하는 것이 더 안정적입니다.
+
+1. **Supabase Dashboard 접속**
+   - https://supabase.com/dashboard
+
+2. **프로젝트 선택 → Settings → Database**
+
+3. **Connection string 섹션에서 "Direct connection" 선택**
+
+4. **Connection string 복사**
+   - 형식: `postgresql://postgres.utvpqdncdsfhcdxkpyls:[PASSWORD]@db.utvpqdncdsfhcdxkpyls.supabase.co:5432/postgres`
+   - 포트는 보통 `5432` 또는 `6543`
+
+5. **로컬 `.env` 파일 수정**
+   ```env
+   # Direct Connection (로컬 개발용)
+   DATABASE_URL="postgresql://postgres.utvpqdncdsfhcdxkpyls:[PASSWORD]@db.utvpqdncdsfhcdxkpyls.supabase.co:5432/postgres"
+   ```
+
+6. **비밀번호 URL 인코딩 확인**
+   - 특수문자가 있다면 URL 인코딩 필요
+   - 예: `!` → `%21`, `@` → `%40`, `#` → `%23`
+
+7. **개발 서버 재시작**
+   ```bash
+   # 개발 서버 중지 후 재시작
+   npm run dev
+   ```
+
+### 방법 2: Supabase 프로젝트 재시작
+
+프로젝트가 일시 중지된 경우:
+
+1. **Supabase Dashboard 접속**
+2. **프로젝트 선택**
+3. **Settings → General**
+4. **"Restore project"** 또는 **"Resume project"** 클릭
+5. **재시작 완료 대기 (2-3분)**
+6. **로컬 개발 서버 재시작**
+
+### 방법 3: Connection String 재확인
+
+1. **Supabase Dashboard → Settings → Database**
+2. **Connection string → Session mode** 선택
+3. **최신 Connection string 복사**
+4. **로컬 `.env` 파일에 업데이트**
+5. **비밀번호 URL 인코딩 확인**
+6. **개발 서버 재시작**
+
+## 📋 체크리스트
+
+- [ ] Supabase 프로젝트가 활성화되어 있는지 확인
+- [ ] Direct Connection으로 변경 시도
+- [ ] 비밀번호 URL 인코딩 확인 (`!` → `%21`)
+- [ ] `.env` 파일의 `DATABASE_URL` 확인
+- [ ] 개발 서버 재시작
+- [ ] 로그인 다시 시도
+
+## 💡 권장 설정
+
+### 로컬 개발 환경 (`.env`)
+```env
+# Direct Connection 사용 (로컬에서 더 안정적)
+DATABASE_URL="postgresql://postgres.utvpqdncdsfhcdxkpyls:[PASSWORD]@db.utvpqdncdsfhcdxkpyls.supabase.co:5432/postgres"
+```
+
+### 프로덕션 환경 (Vercel)
+```env
+# Session Pooler 사용 (Vercel에서 더 안정적)
+DATABASE_URL="postgresql://postgres.utvpqdncdsfhcdxkpyls:[PASSWORD]@aws-1-ap-northeast-2.pooler.supabase.com:5432/postgres?pgbouncer=true"
+```
+
+## 🔄 문제 해결 후
+
+1. 로컬 개발 서버 재시작
+2. 로그인 다시 시도
+3. 연결 성공 확인
+


### PR DESCRIPTION
## 🐛 버그 수정: JWT 인증 시스템에서 서버 컴포넌트 인증 문제

### 문제
JWT 인증 시스템으로 전환 후, 서버 컴포넌트에서 localStorage에 저장된 JWT 토큰을 읽을 수 없어 인증이 필요한 페이지들이 계속 로그인 페이지로 리다이렉트되던 문제

### 해결 방법
- 인증이 필요한 페이지들을 클라이언트 컴포넌트로 변경
- `getCurrentUser()` API를 사용하여 클라이언트에서 인증 상태 확인
- `getSessionUser()` 함수를 JWT 토큰 지원하도록 수정 (향후 서버 컴포넌트에서도 사용 가능)

### 수정된 페이지
- 새 글 작성 페이지 (`/articles/new`)
- 검토 페이지 (`/admin/review`)
- 글 수정 페이지 (`/articles/[slug]/edit`)